### PR TITLE
Add GTF to handlers response template map

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@
 ## General
 This tool provides a simple framework for generating performance test-ready mocks from configuration files.
 
+## Table of Contents
+<!-- TOC -->
+
+- [mockserver](#mockserver)
+    - [General](#general)
+    - [Table of Contents](#table-of-contents)
+    - [Dependencies](#dependencies)
+    - [Building](#building)
+        - [Docker](#docker)
+        - [Locally](#locally)
+    - [Testing](#testing)
+        - [Locally](#locally-1)
+    - [Configuration](#configuration)
+        - [Services](#services)
+        - [Response Bodies](#response-bodies)
+            - [Template Parameters](#template-parameters)
+                - [URL Variables](#url-variables)
+        - [Drivers](#drivers)
+            - [Simple](#simple)
+                - [Example](#example)
+
+<!-- /TOC -->
+
 ## Dependencies
 - make
 
@@ -38,8 +61,21 @@ The mockserver service can be configured via the following environment variables
 - ADDR:        `string` The server address mockserver binds to.
 - CONFIG_PATH: `string` A filesystem path to the simple driver config file.
 
+### Response Bodies
+All response bodies in for handlers are valid [go templates](https://golang.org/pkg/html/template/). In addition some helper data is included in each template variable to be referenced for rendering. This includes the following:
+
+- Template Parameters
+- GTF Functions
+
+#### Template Parameters
+Template parameters are passed directly into the template via the [data argument at time of execution](https://golang.org/pkg/html/template/#Template.Execute) and include both the `http.Request` object for the request that generated the template as well as any path variables that are parsed from the request URL.
+
+##### URL Variables
+The mockserver allow for the parsing of variables directly out of a url path through the [gorilla/mux router](http://www.gorillatoolkit.org/pkg/mux#Vars) and more information on what kind of pattern matching can be accomplished by the router can be found at the preceeding link.
+
 ### Drivers
 #### Simple
+##### Example
 ```yaml
 ---
 - path: "/test/pathvar/{embed}"

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ncatelli/mockserver
 require (
 	github.com/caarlos0/env/v6 v6.1.0
 	github.com/gorilla/mux v1.7.3
+	github.com/leekchan/gtf v0.0.0-20190214083521-5fba33c5b00b
 	gopkg.in/yaml.v2 v2.2.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/caarlos0/env/v6 v6.1.0/go.mod h1:iUA6X3VCAOwDhoqvgKlTGjjwJzQseIJaFYAp
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/leekchan/gtf v0.0.0-20190214083521-5fba33c5b00b h1:ozQQA/k08pNmaav0AxE/EYzN4jvzvhD2idtcHcSAOSA=
+github.com/leekchan/gtf v0.0.0-20190214083521-5fba33c5b00b/go.mod h1:thNruaSwydMhkQ8dXzapABF9Sc1Tz08ZBcDdgott9RA=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/pkg/router/handler.go
+++ b/pkg/router/handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/leekchan/gtf"
 )
 
 type templateVariables struct {
@@ -46,7 +47,7 @@ func (handler *Handler) getBodyTemplate() (*template.Template, error) {
 		body = string(bb)
 	}
 
-	t, err := template.New("").Parse(body)
+	t, err := template.New("").Funcs(gtf.GtfFuncMap).Parse(body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Introduction
This PR adds https://github.com/leekchan/gtf to the function map for the template associated with a handlers response body. This allows additional helper methods for rendering templates.

# Linked Issues
resolves #13 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment

