### PR TITLE
Adds a middleware for artificial latency injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This tool provides a simple framework for generating performance test-ready mock
         - [Middlewares](#middlewares)
             - [logging](#logging)
                 - [settings](#settings)
+            - [latency](#latency)
+                - [settings](#settings-1)
 
 <!-- /TOC -->
 
@@ -171,3 +173,11 @@ The logging handler implements the [gorilla logging handler](https://godoc.org/g
 
 ##### settings
 target (default: `stdout`): a target to write files to. Currently this only supports stdout.
+
+#### latency
+The latency middleware allows injection of artificial latency into a route to mimic either transit or processing time. This latency can be specified either as a static value or as a range of time.
+
+##### settings
+latency (default: `0`): A static latency in milliseconds to inject into a response.
+min     (default: `0`): A minimum value for a range of latency in a response.
+max     (default: `0`): A maximum value for a range of latency in a response.

--- a/examples/simple_driver.yaml
+++ b/examples/simple_driver.yaml
@@ -41,3 +41,14 @@
       content-type: text/plain
     static_response: 'ok'
     response_status: 200
+- path: "/test/with/artificial/latency"
+  method: GET
+  middleware:
+    latency:
+      latency: 100
+  handlers:
+  - weight: 1
+    response_headers:
+      content-type: text/plain
+    static_response: 'ok'
+    response_status: 200

--- a/pkg/router/middleware/middleware.go
+++ b/pkg/router/middleware/middleware.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 
+	"github.com/ncatelli/mockserver/pkg/router/middleware/middlewares/latency"
 	"github.com/ncatelli/mockserver/pkg/router/middleware/middlewares/logging"
 )
 
@@ -12,6 +13,7 @@ var (
 
 func init() {
 	middlewares["logging"] = &logging.Middleware{}
+	middlewares["latency"] = &latency.Middleware{}
 }
 
 // Middleware defines the necessary functions to configure and implement a

--- a/pkg/router/middleware/middlewares/latency/latency.go
+++ b/pkg/router/middleware/middlewares/latency/latency.go
@@ -1,4 +1,4 @@
-package logging
+package latency
 
 import (
 	"math/rand"

--- a/pkg/router/middleware/middlewares/latency/latency.go
+++ b/pkg/router/middleware/middlewares/latency/latency.go
@@ -1,0 +1,70 @@
+package logging
+
+import (
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Middleware is a latency middleware that causes a response to sleep
+// for a predetermined amount of time simulating transit/processing
+// latency
+type Middleware struct {
+	Latency int // A static latency in milliseconds
+	Min     int // A minumum latency for a random range
+	Max     int // a maximum latency for a random range
+}
+
+// Init takes a configuration mapping for either static latency or a latency
+// range.
+func (latency *Middleware) Init(conf map[string]string) error {
+	if v, prs := conf["latency"]; prs == true {
+		l, e := strconv.Atoi(v)
+		if e != nil {
+			return e
+		}
+
+		latency.Latency = l
+	}
+
+	if v, prs := conf["min"]; prs == true {
+		min, e := strconv.Atoi(v)
+		if e != nil {
+			return e
+		}
+
+		latency.Min = min
+	}
+
+	if v, prs := conf["max"]; prs == true {
+		max, e := strconv.Atoi(v)
+		if e != nil {
+			return e
+		}
+
+		latency.Max = max
+	}
+
+	return nil
+}
+
+// Middleware implements the Middleware interface and injects latency into a
+// response based on the configurations defined on the handler.
+func (latency *Middleware) Middleware(next http.Handler) http.Handler {
+	var duration int
+
+	if latency.Latency > 0 {
+		duration = latency.Latency
+	} else if (latency.Max >= latency.Min) && latency.Min > 0 {
+		diff := latency.Max - latency.Min
+		r := rand.Intn(diff)
+		duration = r + diff
+	}
+
+	if duration > 0 {
+		time.Sleep(time.Duration(duration) * time.Millisecond)
+	}
+
+	return next
+}

--- a/pkg/router/middleware/middlewares/latency/latency_test.go
+++ b/pkg/router/middleware/middlewares/latency/latency_test.go
@@ -15,36 +15,38 @@ const (
 )
 
 func TestLatencyMiddlewareShould(t *testing.T) {
-	var wg sync.WaitGroup
-	for i := 0; i < 1000; i++ {
-		wg.Add(1)
+	t.Run("stay within a range of responses.", func(t *testing.T) {
+		var wg sync.WaitGroup
+		for i := 0; i < 1000; i++ {
+			wg.Add(1)
 
-		go func() {
-			defer wg.Done()
-			req, err := http.NewRequest("GET", "/", nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+			go func() {
+				defer wg.Done()
+				req, err := http.NewRequest("GET", "/", nil)
+				if err != nil {
+					t.Fatal(err)
+				}
 
-			router := mux.NewRouter()
-			router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {}).Methods("GET")
+				router := mux.NewRouter()
+				router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {}).Methods("GET")
 
-			latencyMiddleware := &Middleware{Latency: 1000}
+				latencyMiddleware := &Middleware{Latency: 1000}
 
-			router.Use(latencyMiddleware.Middleware)
+				router.Use(latencyMiddleware.Middleware)
 
-			rr := httptest.NewRecorder()
+				rr := httptest.NewRecorder()
 
-			// start timer
-			start := time.Now()
-			router.ServeHTTP(rr, req)
-			duration := time.Since(start)
+				// start timer
+				start := time.Now()
+				router.ServeHTTP(rr, req)
+				duration := time.Since(start)
 
-			if duration.Milliseconds() < 1000 || duration.Milliseconds() > 2000 {
-				t.Errorf(errFmt, "between 1000 - 2000", duration.Milliseconds())
-			}
-		}()
-	}
+				if duration.Milliseconds() < 1000 || duration.Milliseconds() > 2000 {
+					t.Errorf(errFmt, "between 1000 - 2000", duration.Milliseconds())
+				}
+			}()
+		}
 
-	wg.Wait()
+		wg.Wait()
+	})
 }

--- a/pkg/router/middleware/middlewares/latency/latency_test.go
+++ b/pkg/router/middleware/middlewares/latency/latency_test.go
@@ -1,4 +1,4 @@
-package logging
+package latency
 
 import (
 	"fmt"

--- a/pkg/router/middleware/middlewares/latency/latency_test.go
+++ b/pkg/router/middleware/middlewares/latency/latency_test.go
@@ -155,8 +155,8 @@ func TestLatencyMiddlewareShould(t *testing.T) {
 	})
 
 	t.Run("stay within a range of responses within min/max", func(t *testing.T) {
-		var expectedMin int = 1000
-		var expectedMax int = 2000
+		var expectedMin = 1000
+		var expectedMax = 2000
 
 		var wg sync.WaitGroup
 

--- a/pkg/router/middleware/middlewares/latency/latency_test.go
+++ b/pkg/router/middleware/middlewares/latency/latency_test.go
@@ -1,7 +1,13 @@
 package logging
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
 )
 
 const (
@@ -9,5 +15,36 @@ const (
 )
 
 func TestLatencyMiddlewareShould(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
 
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequest("GET", "/", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			router := mux.NewRouter()
+			router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {}).Methods("GET")
+
+			latencyMiddleware := &Middleware{Latency: 1000}
+
+			router.Use(latencyMiddleware.Middleware)
+
+			rr := httptest.NewRecorder()
+
+			// start timer
+			start := time.Now()
+			router.ServeHTTP(rr, req)
+			duration := time.Since(start)
+
+			if duration.Milliseconds() < 1000 || duration.Milliseconds() > 2000 {
+				t.Errorf(errFmt, "between 1000 - 2000", duration.Milliseconds())
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/pkg/router/middleware/middlewares/latency/latency_test.go
+++ b/pkg/router/middleware/middlewares/latency/latency_test.go
@@ -1,0 +1,13 @@
+package logging
+
+import (
+	"testing"
+)
+
+const (
+	errFmt string = "want %v, got %v"
+)
+
+func TestLatencyMiddlewareShould(t *testing.T) {
+
+}

--- a/pkg/router/middleware/middlewares/latency/latency_test.go
+++ b/pkg/router/middleware/middlewares/latency/latency_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +15,76 @@ import (
 const (
 	errFmt string = "want %v, got %v"
 )
+
+func TestLatencyMiddlewareInitShould(t *testing.T) {
+	t.Run("parse a valid latency parameter", func(t *testing.T) {
+		unparsedLatency := "50"
+		expectedLatency := 50
+
+		m := &Middleware{}
+		conf := map[string]string{"latency": unparsedLatency}
+
+		err := m.Init(conf)
+		if err != nil {
+			t.Errorf(errFmt, nil, err)
+		}
+
+		if m.Latency != expectedLatency {
+			t.Errorf(errFmt, expectedLatency, m.Latency)
+		}
+	})
+
+	t.Run("throw an err when the latency parameter is invalid", func(t *testing.T) {
+		unparsedInvalidLatency := "invalidParam"
+
+		m := &Middleware{}
+		conf := map[string]string{"latency": unparsedInvalidLatency}
+
+		err := m.Init(conf)
+		if err == nil {
+			t.Errorf(errFmt, "error", nil)
+		}
+	})
+
+	t.Run("parse valid min/max parameters", func(t *testing.T) {
+		unparsedMin := "50"
+		expectedMin := 50
+		unparsedMax := "100"
+		expectedMax := 100
+
+		expectedMiddleware := &Middleware{
+			Min: expectedMin,
+			Max: expectedMax,
+		}
+
+		m := &Middleware{}
+		conf := map[string]string{
+			"min": unparsedMin,
+			"max": unparsedMax,
+		}
+
+		err := m.Init(conf)
+		if err != nil {
+			t.Errorf(errFmt, nil, err)
+		}
+
+		if !reflect.DeepEqual(expectedMiddleware, m) {
+			t.Errorf(errFmt, expectedMiddleware, m)
+		}
+	})
+
+	t.Run("throw an err when the min/max parameters is invalid", func(t *testing.T) {
+		unparsedInvalidLatency := "invalidParam"
+
+		m := &Middleware{}
+		conf := map[string]string{"latency": unparsedInvalidLatency}
+
+		err := m.Init(conf)
+		if err == nil {
+			t.Errorf(errFmt, "error", nil)
+		}
+	})
+}
 
 func TestLatencyMiddlewareShould(t *testing.T) {
 	t.Run("stay within a range of responses of latency setting", func(t *testing.T) {

--- a/pkg/router/middleware/middlewares/latency/latency_test.go
+++ b/pkg/router/middleware/middlewares/latency/latency_test.go
@@ -74,10 +74,13 @@ func TestLatencyMiddlewareInitShould(t *testing.T) {
 	})
 
 	t.Run("throw an err when the min/max parameters is invalid", func(t *testing.T) {
-		unparsedInvalidLatency := "invalidParam"
+		unparsedInvalidParam := "invalidParam"
 
 		m := &Middleware{}
-		conf := map[string]string{"latency": unparsedInvalidLatency}
+		conf := map[string]string{
+			"min": unparsedInvalidParam,
+			"max": unparsedInvalidParam,
+		}
 
 		err := m.Init(conf)
 		if err == nil {


### PR DESCRIPTION
# Introduction
This PR adds a middleware that allows specification of latency in milliseconds to inject into a response to mock transit latency. This latency can be expressed as a static value or as a range of time.

# Linked Issues
resolves #15 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment

