### PR TITLE
Add catches for when a handler weight exceeds max

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ This field represents a key-value mapping of query parameters that must be set t
 ###### Handlers
 The handlers field takes a weighted list of objects that map directly to the Handler structure. Subfields of handlers represent
 
-- weight: A weighted value to determine the frequency a handler is hit. Higher represents more frequent.
+- weight: A positive weighted value to determine the frequency a handler is hit. Higher represents more frequent hits. Zero represents unrouteable (good for a temporarily disabled handler).
 - response_headers: A key-value store of additional headers to be attached to the response body.
 - static_response: A response body template to respond with. This supercedes the response_path setting and is suitable for short responses.
 - response_path: A file path to a file that will be used to generate the response body. This is more suitable for multi-line responses that will be difficult to fit into a static_response.

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -95,7 +95,7 @@ func calculateTotalWeightofHandlers(handlers []Handler) (int, error) {
 	for _, h := range handlers {
 		maxhandlerWeight := maxInt64 - totalWeight
 
-		if (h.Weight > maxInt64) || h.Weight > maxhandlerWeight {
+		if h.Weight > maxInt64 || h.Weight > maxhandlerWeight || h.Weight < 0 {
 			return -1, ErrInvalidWeight{
 				handler: &h,
 			}

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -1,12 +1,27 @@
 package router
 
 import (
+	"fmt"
 	"math/rand"
 	"net/http"
 	"time"
 
 	"github.com/ncatelli/mockserver/pkg/router/middleware"
 )
+
+const (
+	maxInt64 = 1<<63 - 1
+)
+
+// ErrInvalidWeight is thrown when a handler has a weight outside the
+// acceptable bounds.
+type ErrInvalidWeight struct {
+	handler *Handler
+}
+
+func (e ErrInvalidWeight) Error() string {
+	return fmt.Sprintf("handler %v exceeds maximum total weight of %d", *e.handler, maxInt64)
+}
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
@@ -27,7 +42,12 @@ type Route struct {
 
 // Init performs any setup and initialization around the route.
 func (route *Route) Init() error {
-	route.totalWeight = calculateTotalWeightofHandlers(route.Handlers)
+	tw, err := calculateTotalWeightofHandlers(route.Handlers)
+	if err != nil {
+		return err
+	}
+
+	route.totalWeight = tw
 
 	for k, v := range route.Middleware {
 		m := middleware.Lookup(k)
@@ -69,12 +89,20 @@ func (route *Route) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // calculateTotalWeightofHandlers iterates over all handlers assigned to the
 // route and sums their total weight.
-func calculateTotalWeightofHandlers(handlers []Handler) int {
-	var weight int
+func calculateTotalWeightofHandlers(handlers []Handler) (int, error) {
+	var totalWeight int
 
 	for _, h := range handlers {
-		weight += h.Weight
+		maxhandlerWeight := maxInt64 - totalWeight
+
+		if (h.Weight > maxInt64) || h.Weight > maxhandlerWeight {
+			return -1, ErrInvalidWeight{
+				handler: &h,
+			}
+		}
+
+		totalWeight += h.Weight
 	}
 
-	return weight
+	return totalWeight, nil
 }

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -70,8 +70,20 @@ func TestRouteWeightCalculationShould(t *testing.T) {
 
 		got, err := calculateTotalWeightofHandlers(tHandlers)
 
-		if got != -1 && err == nil {
+		if got != -1 || err == nil {
 			t.Errorf(errFmt, ErrInvalidWeight{handler: &tHandlers[1]}, nil)
+		}
+	})
+
+	t.Run("throw an error if a negative weight is defined.", func(t *testing.T) {
+		tHandlers := []Handler{
+			Handler{Weight: -1},
+		}
+
+		got, err := calculateTotalWeightofHandlers(tHandlers)
+
+		if got != -1 || err == nil {
+			t.Errorf(errFmt, ErrInvalidWeight{handler: &tHandlers[0]}, nil)
 		}
 	})
 }

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -55,10 +55,23 @@ func TestRouteWeightCalculationShould(t *testing.T) {
 		}
 
 		expected := 14
-		got := calculateTotalWeightofHandlers(tHandlers)
+		got, _ := calculateTotalWeightofHandlers(tHandlers)
 
 		if expected != got {
 			t.Errorf(errFmt, expected, got)
+		}
+	})
+
+	t.Run("throw an error if the max handler weight would overflow an int64", func(t *testing.T) {
+		tHandlers := []Handler{
+			Handler{Weight: maxInt64},
+			Handler{Weight: 2},
+		}
+
+		got, err := calculateTotalWeightofHandlers(tHandlers)
+
+		if got != -1 && err == nil {
+			t.Errorf(errFmt, ErrInvalidWeight{handler: &tHandlers[1]}, nil)
 		}
 	})
 }


### PR DESCRIPTION
# Introduction
Some simple catches in the router to handle for an overly large weight. This now causes the router to throw an error if calculating max weight exceeds an int64 or if a weight is negative.

# Linked Issues
resolves #23
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment

