### PR TITLE
Fix Init docstring for logging middleware

### DIFF
--- a/pkg/router/middleware/middlewares/logging/logging.go
+++ b/pkg/router/middleware/middlewares/logging/logging.go
@@ -19,12 +19,16 @@ func (e ErrUnknownTarget) Error() string {
 	return fmt.Sprintf("target %s unknown", e.target)
 }
 
-// Middleware is a logging middleware that outputs in NCSA format
+// Middleware is a logging middleware that outputs in CLF format
 type Middleware struct {
 	target io.Writer
 }
 
-// Init takes 0 parameters thus this will always return nil.
+// Init takes a configuration map of strings to configure the middleware. The
+// current only accepted parameter is "target" representing the output target
+// for log data. Currently, "stdout" is the only supported target though this
+// is subject ot change in the future. If no value is specified, "stdout" is
+// default to for the target.
 func (logger *Middleware) Init(conf map[string]string) error {
 	if t, prs := conf["target"]; prs == true {
 		switch t {


### PR DESCRIPTION
# Introduction
This PR fixes small inconsistencies in the docstring for the logging middlewares' Init method.

# Linked Issues
resolves #27 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment

