### PR TITLE
Reload configuration when a sighup is received

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,14 @@
 package main
 
 import (
+	"context"
 	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/gorilla/mux"
 
 	"net/http"
 
@@ -10,12 +17,7 @@ import (
 	"github.com/ncatelli/mockserver/pkg/router/drivers/simple"
 )
 
-func main() {
-	c, e := config.New()
-	if e != nil {
-		log.Fatal("unable to parse config params")
-	}
-
+func buildRouterFromConfig(c *config.Config) *mux.Router {
 	routes, err := simple.LoadFromFile(c.ConfigPath)
 	if err != nil {
 		panic(err)
@@ -26,10 +28,58 @@ func main() {
 		panic(err)
 	}
 
-	router.HandleFunc(`/healthcheck`, healthHandler).Methods("GET")
+	return router
+}
 
-	log.Printf("Starting server on %s\n", c.Addr)
-	if err := http.ListenAndServe(c.Addr, router); err != nil {
-		log.Fatalf("Error in ListenAndServe: %s", err)
+func startHTTPServer(c *config.Config, wg *sync.WaitGroup) *http.Server {
+	router := buildRouterFromConfig(c)
+	router.HandleFunc(`/healthcheck`, healthHandler).Methods("GET")
+	srv := &http.Server{
+		Addr:    c.Addr,
+		Handler: router,
+	}
+
+	go func() {
+		defer wg.Done() // let main know we are done cleaning up
+
+		// always returns error. ErrServerClosed on graceful close
+		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
+			// unexpected error. port in use?
+			log.Fatalf("ListenAndServe(): %v", err)
+		}
+	}()
+
+	// returning reference so caller can call Shutdown()
+	return srv
+}
+
+func main() {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGHUP)
+
+	for {
+		c, e := config.New()
+		if e != nil {
+			log.Fatal("unable to parse config params")
+		}
+
+		log.Printf("Starting server on %s\n", c.Addr)
+
+		httpServerExitDone := &sync.WaitGroup{}
+		httpServerExitDone.Add(1)
+		srv := startHTTPServer(&c, httpServerExitDone)
+
+		// blocks for shutdown. If a SIGHUP happens it will gracefully
+		// restart the server.
+		<-sigs
+
+		log.Println("reloading configuration...")
+
+		if err := srv.Shutdown(context.TODO()); err != nil {
+			panic(err) // failure/timeout shutting down the server gracefully
+		}
+
+		// wait for goroutine started in startHttpServer() to stop
+		httpServerExitDone.Wait()
 	}
 }


### PR DESCRIPTION
# Introduction
This PR introduces signal handling so that the server now catches a `SIGHUP` and uses it to trigger a configuration reload.

# Linked Issues
resolves #32 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment

