### PR TITLE
Add some minimal benches around the router.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ build-docker: | fmt test
 test:
 	go test -race -cover ./...
 
+benchmark:
+	go test -benchmem -bench . ./...
+
 fmt:
 	test -z $(shell go fmt ./...)
 

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -87,3 +87,45 @@ func TestRouteWeightCalculationShould(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkRouterHandlerSelection(b *testing.B) {
+	b.Run("single handler", func(b *testing.B) {
+		r := Route{
+			Handlers: generateTestHandlerSlice(1, 1),
+		}
+
+		for i := 0; i < b.N; i++ {
+			r.selectHandler()
+		}
+	})
+
+	b.Run("two equally-weighted handlers", func(b *testing.B) {
+		r := Route{
+			Handlers: generateTestHandlerSlice(1, 2),
+		}
+
+		for i := 0; i < b.N; i++ {
+			r.selectHandler()
+		}
+	})
+
+	b.Run("two equally-weighted handlers with large weights", func(b *testing.B) {
+		r := Route{
+			Handlers: generateTestHandlerSlice(100, 2),
+		}
+
+		for i := 0; i < b.N; i++ {
+			r.selectHandler()
+		}
+	})
+}
+
+func generateTestHandlerSlice(weight int, count int) []Handler {
+	h := make([]Handler, count)
+
+	for i := 0; i < count; i++ {
+		h = append(h, Handler{Weight: weight})
+	}
+
+	return h
+}


### PR DESCRIPTION
# Introduction
Minimal benches around the router. These don't prove much more than I already knew, but they could be canaries in the coal mine for future changes/optimizations. The only alternative is potentially a matrix of benchmarks around exponentially increasing numbers of handlers.

# Linked Issues
resolves #31 

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment