### PR TITLE
Load route configuration from a URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,12 @@ $> make test
 ### Services
 The mockserver service can be configured via the following environment variables:
 
-- ADDR:        `string` The server address mockserver binds to.
-- CONFIG_PATH: `string` A filesystem path to the simple driver config file.
+- ADDR:        `string`  The server address mockserver binds to.
+- CONFIG_PATH: `string`  A filesystem path to the simple driver config file.
+- CONFIG_URL:  `url.URL` A URL path to fetch the configuration file from. This
+    is useful for when a service wants to publish its own configuration file.
+
+It's worth noting that _EITHER_ `CONFIG_PATH` or `CONFIG_URL` should be sent. If both are set, `CONFIG_PATH` takes priority.
 
 ### Response Bodies
 All response bodies in for handlers are valid [go templates](https://golang.org/pkg/html/template/). In addition some helper data is included in each template variable to be referenced for rendering. This includes the following:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"io"
+	"net/url"
+
 	"github.com/caarlos0/env/v6"
 )
 
@@ -8,8 +11,9 @@ import (
 // global level. This can include listening address, feature flags and other
 // configurations.
 type Config struct {
-	Addr       string `env:"ADDR" envDefault:"0.0.0.0:8080"`
-	ConfigPath string `env:"CONFIG_PATH"`
+	Addr       string  `env:"ADDR" envDefault:"0.0.0.0:8080"`
+	ConfigPath string  `env:"CONFIG_PATH"`
+	ConfigURL  url.URL `env:"CONFIG_URL"`
 }
 
 // New initializes a Config, attempting to parse parames from Envs.
@@ -21,4 +25,11 @@ func New() (Config, error) {
 	}
 
 	return c, nil
+}
+
+// Load attempts to fetch a Router configuration from one of the optional
+// locations (URL or Filepath). On success it returns an io.Reader for this
+// file otherwise an error is returned.
+func (c *Config) Load() (io.Reader, error) {
+	return nil, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,13 @@ import (
 	"github.com/caarlos0/env/v6"
 )
 
+// ErrUndefinedConfig represents a route configuration hasn't been specified.
+type ErrUndefinedConfig struct{}
+
+func (e *ErrUndefinedConfig) Error() string {
+	return "route configuration has not been specified"
+}
+
 // Config stores configuration parameters for interacting with the server at a
 // global level. This can include listening address, feature flags and other
 // configurations.
@@ -31,5 +38,11 @@ func New() (Config, error) {
 // locations (URL or Filepath). On success it returns an io.Reader for this
 // file otherwise an error is returned.
 func (c *Config) Load() (io.Reader, error) {
-	return nil, nil
+	if len(c.ConfigPath) > 0 {
+
+	} else if len(c.ConfigURL.String()) > 0 {
+
+	}
+
+	return nil, &ErrUndefinedConfig{}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -44,3 +44,14 @@ func TestInitializingAConfigShould(t *testing.T) {
 		}
 	})
 }
+
+func TestConfigurationLoadingShould(t *testing.T) {
+	t.Run("return an ErrUnspecifiedConfig when no config option is set", func(t *testing.T) {
+		c := Config{}
+
+		_, err := c.Load()
+		if err == nil {
+			t.Errorf(errFmt, "error", err)
+		}
+	})
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 const (
-	errFmt           string = "want %v, got %v"
-	goodResponseBody        = `
-- path: "/test/weighted/errors"
+	errFmt              = "want %v, got %v"
+	goodTestFixturePath = "test_fixtures/good.yaml"
+	goodResponseBody    = `- path: "/test"
   method: GET
   handlers:
-    - weight: 2
+    - weight: 1
       response_headers:
         content-type: application/json
       static_response: '{"resp": "Ok"}'
@@ -83,6 +83,25 @@ func TestConfigurationLoadingShould(t *testing.T) {
 		testURL, _ := url.Parse(testServer.URL)
 		c := Config{
 			ConfigURL: *testURL,
+		}
+
+		reader, err := c.Load()
+		if err != nil {
+			t.Errorf(errFmt, nil, err)
+		}
+
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(reader)
+		s := buf.String()
+
+		if !reflect.DeepEqual(goodResponseBody, s) {
+			t.Errorf(errFmt, goodResponseBody, s)
+		}
+	})
+
+	t.Run("load a configuration from a filepath when specified", func(t *testing.T) {
+		c := Config{
+			ConfigPath: goodTestFixturePath,
 		}
 
 		reader, err := c.Load()

--- a/pkg/config/test_fixtures/good.yaml
+++ b/pkg/config/test_fixtures/good.yaml
@@ -1,0 +1,8 @@
+- path: "/test"
+  method: GET
+  handlers:
+    - weight: 1
+      response_headers:
+        content-type: application/json
+      static_response: '{"resp": "Ok"}'
+      response_status: 200

--- a/pkg/router/drivers/simple/config.go
+++ b/pkg/router/drivers/simple/config.go
@@ -1,12 +1,30 @@
 package simple
 
 import (
+	"io"
 	"io/ioutil"
 	"path/filepath"
 
 	"github.com/ncatelli/mockserver/pkg/router"
 	"gopkg.in/yaml.v2"
 )
+
+// Load takes an io.Reader and attempts to unmarshal the configuration into a
+// route slice. On success, a slice of routes and nil is returned, otherwise an
+// error is returned.
+func Load(data io.Reader) ([]*router.Route, error) {
+	routes := make([]*router.Route, 0)
+	b, err := ioutil.ReadAll(data)
+	if err != nil {
+		return routes, err
+	}
+
+	if err = yaml.Unmarshal(b, &routes); err != nil {
+		return routes, err
+	}
+
+	return routes, nil
+}
 
 // LoadFromFile takes a path an attempts to unmarshal a route slice from a yaml
 // file. On success, a slice of routes and nil is returned, otherwise an error

--- a/pkg/router/drivers/simple/config_test.go
+++ b/pkg/router/drivers/simple/config_test.go
@@ -2,6 +2,7 @@ package simple
 
 import (
 	"log"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -11,6 +12,7 @@ import (
 
 const (
 	goodConfigPath string = "test_fixtures/good.yaml"
+	badConfigPath  string = "test_fixtures/bad.yaml"
 	errFmt         string = "want %v, got %v"
 )
 
@@ -38,6 +40,35 @@ var expectedRoutes = []*router.Route{
 	},
 }
 
+func TestLoadShould(t *testing.T) {
+	t.Run("load a valid configuration", func(t *testing.T) {
+		gp, err := filepath.Rel("", goodConfigPath)
+		file, err := os.Open(gp)
+		defer file.Close()
+
+		routes, err := Load(file)
+		if err != nil {
+			t.Errorf(errFmt, expectedRoutes, err)
+		} else if !reflect.DeepEqual(routes, expectedRoutes) {
+			t.Errorf(errFmt, expectedRoutes, routes)
+		}
+	})
+
+	t.Run("return an error a non-yaml parseable file.", func(t *testing.T) {
+		bp, err := filepath.Rel("", badConfigPath)
+		file, err := os.Open(bp)
+		defer file.Close()
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if _, err := LoadFromFile(bp); err == nil {
+			t.Errorf(errFmt, "an error", err)
+		}
+	})
+}
+
 func TestLoadFromFileShould(t *testing.T) {
 	t.Run("load a valid configuration", func(t *testing.T) {
 		gp, err := filepath.Rel("", goodConfigPath)
@@ -54,12 +85,12 @@ func TestLoadFromFileShould(t *testing.T) {
 	})
 
 	t.Run("return an error a non-yaml parseable file.", func(t *testing.T) {
-		bp, err := filepath.Rel("", goodConfigPath)
+		bp, err := filepath.Rel("", badConfigPath)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		if _, err := LoadFromFile(bp); err != nil {
+		if _, err := LoadFromFile(bp); err == nil {
 			t.Errorf(errFmt, "an error", err)
 		}
 	})

--- a/pkg/router/drivers/simple/config_test.go
+++ b/pkg/router/drivers/simple/config_test.go
@@ -1,8 +1,8 @@
 package simple
 
 import (
+	"bytes"
 	"log"
-	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -14,6 +14,25 @@ const (
 	goodConfigPath string = "test_fixtures/good.yaml"
 	badConfigPath  string = "test_fixtures/bad.yaml"
 	errFmt         string = "want %v, got %v"
+)
+
+var (
+	goodConfig = []byte(`
+- path: "/test/weighted/errors"
+  method: GET
+  handlers:
+    - weight: 2
+      response_headers:
+        content-type: application/json
+      static_response: '{"resp": "Ok"}'
+      response_status: 200
+    - weight: 1
+      response_headers:
+        content-type: text/plain
+      static_response: ''
+      response_status: 500
+`)
+	badConfig = []byte(";189na--ac")
 )
 
 var expectedRoutes = []*router.Route{
@@ -42,11 +61,7 @@ var expectedRoutes = []*router.Route{
 
 func TestLoadShould(t *testing.T) {
 	t.Run("load a valid configuration", func(t *testing.T) {
-		gp, err := filepath.Rel("", goodConfigPath)
-		file, err := os.Open(gp)
-		defer file.Close()
-
-		routes, err := Load(file)
+		routes, err := Load(bytes.NewReader(goodConfig))
 		if err != nil {
 			t.Errorf(errFmt, expectedRoutes, err)
 		} else if !reflect.DeepEqual(routes, expectedRoutes) {
@@ -54,16 +69,9 @@ func TestLoadShould(t *testing.T) {
 		}
 	})
 
-	t.Run("return an error a non-yaml parseable file.", func(t *testing.T) {
-		bp, err := filepath.Rel("", badConfigPath)
-		file, err := os.Open(bp)
-		defer file.Close()
-
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if _, err := LoadFromFile(bp); err == nil {
+	t.Run("return an error on a non-valid configuration", func(t *testing.T) {
+		_, err := Load(bytes.NewReader(badConfig))
+		if err == nil {
 			t.Errorf(errFmt, "an error", err)
 		}
 	})


### PR DESCRIPTION
# Introduction
This PR adds the optional ability to load a configuration from a URL path.

# Linked Issues
resolves #16 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment

