### PR TITLE
Update error endpoint to use http.Error

### DIFF
--- a/pkg/router/handler.go
+++ b/pkg/router/handler.go
@@ -60,7 +60,7 @@ func (handler *Handler) getBodyTemplate() (*template.Template, error) {
 func (handler *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	t, err := handler.getBodyTemplate()
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+		http.Error(w, "", http.StatusInternalServerError)
 		return
 	}
 


### PR DESCRIPTION
# Introduction
Small PR to update error writes to use http.Error in place of manual header writes.
# Linked Issues
resolves #42 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment

