### PR TITLE
Fix multi-handler responses only returning last response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+mockserver
 
 # Test binary, built with `go test -c`
 *.test
@@ -13,4 +14,3 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
-mockerserver

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/main.go",
+            "env": {
+                "ADDR": "0.0.0.0:8080",
+                "CONFIG_PATH": "${workspaceFolder}/examples/simple_driver.yaml"
+            },
+            "args": []
+        }
+    ]
+}

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -89,6 +89,7 @@ func (route *Route) selectHandler() http.Handler {
 		hw -= h.Weight
 		if hw <= 0 {
 			handler = &h
+			break
 		}
 	}
 

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -68,7 +68,7 @@ func (route *Route) Init() error {
 // ServeHTTP implements the http.Handler interface for pipelining a request
 // further into a handler.
 func (route *Route) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	handler := route.selectHandler()
+	handler := route.selectHandler(rand.Intn(route.totalWeight + 1))
 
 	// Generate handler chain with middlewares
 	for i := len(route.middlewareHandlers) - 1; i >= 0; i-- {
@@ -80,9 +80,8 @@ func (route *Route) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // selectHandler randomly selects and returns a handler from the route
 // handlers pool.
-func (route *Route) selectHandler() http.Handler {
+func (route *Route) selectHandler(hw int) http.Handler {
 	var handler http.Handler
-	hw := rand.Intn(route.totalWeight + 1)
 
 	// make handler selection based on weight.
 	for _, h := range route.Handlers {

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -3,6 +3,7 @@ package router
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"reflect"
 	"testing"
 
@@ -90,6 +91,24 @@ func TestRouteWeightCalculationShould(t *testing.T) {
 	})
 }
 
+func TestHandlerSelectionShould(t *testing.T) {
+	t.Run("return the first handler that brings the handler weight to 0", func(t *testing.T) {
+		r := Route{
+			Handlers: []Handler{
+				Handler{Weight: 2},
+				Handler{Weight: 1},
+			},
+		}
+
+		expected := &r.Handlers[0]
+		got := r.selectHandler(2)
+
+		if !reflect.DeepEqual(expected, got) {
+			t.Errorf(errFmt, expected, got)
+		}
+	})
+}
+
 func BenchmarkRouterHandlerSelectionWith(b *testing.B) {
 	for x := 0.0; x <= 6; x++ {
 		pow := math.Pow(2, x)
@@ -100,7 +119,7 @@ func BenchmarkRouterHandlerSelectionWith(b *testing.B) {
 			}
 
 			for i := 0; i < b.N; i++ {
-				r.selectHandler()
+				r.selectHandler(rand.Intn(r.totalWeight + 1))
 			}
 		})
 	}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -152,5 +152,4 @@ func TestRouterShouldNotMatch(t *testing.T) {
 			t.Errorf(errFmt, true, false)
 		}
 	})
-
 }


### PR DESCRIPTION
# Introduction
This fixes a bug where the last handler in a multi-handler route is selected due to the case never breaking when the handlerWeight is less than 0. This explicitly adds a break out of the loop when routeSelection conditions are met.

# Linked Issues
resolves #50 

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment

