### PR TITLE
version bump from go 1.13 -> go 1.14.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM golang:1.13
+FROM golang:1.14
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -9,5 +9,5 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v1
       with:
-        go-version: '1.13.6'
+        go-version: '1.14.0'
     - run: make test

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -9,5 +9,5 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v1
       with:
-        go-version: '1.14.0'
+        go-version: '1.14'
     - run: make test

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	gopkg.in/yaml.v2 v2.2.2
 )
 
-go 1.13
+go 1.14


### PR DESCRIPTION
# Introduction
This PR bumps go in both the devcontainer and in go modules from go 1.13 -> go 1.14.

# Linked Issues
resolves #53 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment

