### PR TITLE
Use stride scheduler for handler selection

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -9,5 +9,5 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-go@v1
       with:
-        go-version: '1.14'
+        go-version: '1.16'
     - run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASEIMG="alpine:3.11"
-ARG BUILDIMG="golang:1.13.6-alpine3.11"
+ARG BASEIMG="alpine:3.14"
+ARG BUILDIMG="golang:1.16-alpine"
 FROM $BUILDIMG as builder
 
 ARG APP_NAME="mockserver"

--- a/pkg/router/handler.go
+++ b/pkg/router/handler.go
@@ -20,7 +20,7 @@ type templateVariables struct {
 
 // Handler includes all the metadata to decide on and serve a response.
 type Handler struct {
-	Weight          int               `yaml:"weight"`
+	Weight          uint              `yaml:"weight"`
 	ResponseHeaders map[string]string `yaml:"response_headers"`
 	StaticResponse  string            `yaml:"static_response"`
 	ResponseStatus  int               `yaml:"response_status"`

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -105,10 +105,13 @@ func (route *Route) Init() error {
 // ServeHTTP implements the http.Handler interface for pipelining a request
 // further into a handler.
 func (route *Route) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	var lowestPassIdx uint = 0
+	// set to max of uint so first value is guaranteed to be <= value.
+	var lowestPass = ^uint(0)
+	lowestPassIdx := 0
 	for idx, h := range route.strideHandlers {
-		if h.pass < lowestPassIdx {
-			lowestPassIdx = uint(idx)
+		if h.pass < lowestPass {
+			lowestPass = h.pass
+			lowestPassIdx = idx
 		}
 	}
 

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -103,9 +103,9 @@ func (route *Route) Init() error {
 			// incrememt pass by stride
 			sH.pass += sH.stride
 
-			var middlewareHandler http.Handler
+			var middlewareHandler http.Handler = sH
 			// Generate handler chain with middlewares
-			for i := middlewareCount - 1; i >= 0; i-- {
+			for i := middlewareCount; i > 0; i-- {
 				middlewareHandler = middlewareHandlers[i].Middleware(sH)
 			}
 

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -27,6 +27,7 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
+// StrideHandlers wraps the Handler type with a precomputed stride and pass context.
 type StrideHandler struct {
 	pass    uint
 	stride  uint

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -78,3 +78,46 @@ func TestHandlerSelectionShould(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkRouterHandlerSelectionWith(b *testing.B) {
+	successHandler := Handler{
+		Weight:         1,
+		ResponseStatus: 200,
+		StaticResponse: "Ok",
+	}
+	failureHandler := Handler{
+		Weight:         1,
+		ResponseStatus: 500,
+		StaticResponse: "",
+	}
+	b.Run("equally-weighted handlers", func(b *testing.B) {
+		r := &Route{
+			Path:     "/",
+			Method:   "GET",
+			Handlers: []Handler{successHandler, failureHandler},
+		}
+		r.Init()
+
+		for i := 0; i < b.N; i++ {
+			<-r.handlerChan
+		}
+
+	})
+
+	b.Run("unequally-weighted handlers", func(b *testing.B) {
+		unequalSuccessHandler := successHandler
+		unequalSuccessHandler.Weight = 2
+		r := &Route{
+			Path:     "/",
+			Method:   "GET",
+			Handlers: []Handler{unequalSuccessHandler, failureHandler},
+		}
+		r.Init()
+
+		for i := 0; i < b.N; i++ {
+			<-r.handlerChan
+		}
+
+	})
+
+}

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -1,9 +1,6 @@
 package router
 
 import (
-	"fmt"
-	"math"
-	"math/rand"
 	"reflect"
 	"testing"
 
@@ -41,53 +38,18 @@ func TestRouteInitShould(t *testing.T) {
 
 		tRoute.Init()
 
-		expected := 3
-		got := tRoute.totalWeight
-
-		if expected != got {
-			t.Errorf(errFmt, expected, got)
-		}
-	})
-}
-func TestRouteWeightCalculationShould(t *testing.T) {
-	t.Run("return the sum of all handler weights", func(t *testing.T) {
-		tHandlers := []Handler{
-			Handler{Weight: 1},
-			Handler{Weight: 10},
-			Handler{Weight: 3},
+		expected := []int{2, 1}
+		got := make([]int, 0, len(tRoute.strideHandlers))
+		for _, sH := range tRoute.strideHandlers {
+			got = append(got, sH.stride)
 		}
 
-		expected := 14
-		got, _ := calculateTotalWeightofHandlers(tHandlers)
-
-		if expected != got {
-			t.Errorf(errFmt, expected, got)
-		}
-	})
-
-	t.Run("throw an error if the max handler weight would overflow an int64", func(t *testing.T) {
-		tHandlers := []Handler{
-			Handler{Weight: maxInt64},
-			Handler{Weight: 2},
+		for i, expectedStride := range expected {
+			if expectedStride != got[i] {
+				t.Errorf(errFmt, expectedStride, got[i])
+			}
 		}
 
-		got, err := calculateTotalWeightofHandlers(tHandlers)
-
-		if got != -1 || err == nil {
-			t.Errorf(errFmt, ErrInvalidWeight{handler: &tHandlers[1]}, nil)
-		}
-	})
-
-	t.Run("throw an error if a negative weight is defined.", func(t *testing.T) {
-		tHandlers := []Handler{
-			Handler{Weight: -1},
-		}
-
-		got, err := calculateTotalWeightofHandlers(tHandlers)
-
-		if got != -1 || err == nil {
-			t.Errorf(errFmt, ErrInvalidWeight{handler: &tHandlers[0]}, nil)
-		}
 	})
 }
 
@@ -107,30 +69,4 @@ func TestHandlerSelectionShould(t *testing.T) {
 			t.Errorf(errFmt, expected, got)
 		}
 	})
-}
-
-func BenchmarkRouterHandlerSelectionWith(b *testing.B) {
-	for x := 0.0; x <= 6; x++ {
-		pow := math.Pow(2, x)
-		h := generateTestHandlerSlice(1, int(pow))
-		b.Run(fmt.Sprintf("%.0f equally-weighted handlers", pow), func(b *testing.B) {
-			r := Route{
-				Handlers: h,
-			}
-
-			for i := 0; i < b.N; i++ {
-				r.selectHandler(rand.Intn(r.totalWeight + 1))
-			}
-		})
-	}
-}
-
-func generateTestHandlerSlice(weight int, count int) []Handler {
-	h := make([]Handler, count)
-
-	for i := 0; i < count; i++ {
-		h = append(h, Handler{Weight: weight})
-	}
-
-	return h
 }

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -28,7 +28,7 @@ func TestRouteUnmarshalingShould(t *testing.T) {
 }
 
 func TestRouteInitShould(t *testing.T) {
-	t.Run("assign the total weight of all handlers to the route", func(t *testing.T) {
+	t.Run("generate the expected stride value for each route.", func(t *testing.T) {
 		tRoute := Route{
 			Handlers: []Handler{
 				{Weight: 1},

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -1,9 +1,12 @@
 package router
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
+	"github.com/gorilla/mux"
 	"gopkg.in/yaml.v2"
 )
 
@@ -28,5 +31,50 @@ func TestRouteUnmarshalingShould(t *testing.T) {
 }
 
 func TestHandlerSelectionShould(t *testing.T) {
+	successHandler := Handler{
+		Weight:         2,
+		ResponseStatus: 200,
+		StaticResponse: "Ok",
+	}
+	failureHandler := Handler{
+		Weight:         1,
+		ResponseStatus: 500,
+		StaticResponse: "",
+	}
 
+	t.Run("return handlers in deterministic pattern for weight", func(t *testing.T) {
+		r := &Route{
+			Path:     "/",
+			Method:   "GET",
+			Handlers: []Handler{successHandler, failureHandler},
+		}
+		r.Init()
+
+		samples := 9
+		responses := make([]*httptest.ResponseRecorder, 0, samples)
+
+		for i := 0; i < samples; i++ {
+			req, err := http.NewRequest("GET", "/", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder()
+			router := mux.NewRouter()
+			router.Handle("/", r).Methods("GET")
+
+			router.ServeHTTP(rr, req)
+			responses = append(responses, rr)
+		}
+
+		expectedResponseCodes := []int{200, 500, 200, 500, 200, 200, 500, 200, 200}
+		responseCodes := make([]int, 0, len(responses))
+		for _, res := range responses {
+			responseCodes = append(responseCodes, res.Code)
+		}
+
+		if !reflect.DeepEqual(expectedResponseCodes, responseCodes) {
+			t.Errorf(errFmt, expectedResponseCodes, responseCodes)
+		}
+	})
 }

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -31,15 +31,15 @@ func TestRouteInitShould(t *testing.T) {
 	t.Run("assign the total weight of all handlers to the route", func(t *testing.T) {
 		tRoute := Route{
 			Handlers: []Handler{
-				Handler{Weight: 1},
-				Handler{Weight: 2},
+				{Weight: 1},
+				{Weight: 2},
 			},
 		}
 
 		tRoute.Init()
 
-		expected := []int{2, 1}
-		got := make([]int, 0, len(tRoute.strideHandlers))
+		expected := []uint{2, 1}
+		got := make([]uint, 0, len(tRoute.strideHandlers))
 		for _, sH := range tRoute.strideHandlers {
 			got = append(got, sH.stride)
 		}
@@ -54,19 +54,5 @@ func TestRouteInitShould(t *testing.T) {
 }
 
 func TestHandlerSelectionShould(t *testing.T) {
-	t.Run("return the first handler that brings the handler weight to 0", func(t *testing.T) {
-		r := Route{
-			Handlers: []Handler{
-				Handler{Weight: 2},
-				Handler{Weight: 1},
-			},
-		}
 
-		expected := &r.Handlers[0]
-		got := r.selectHandler(2)
-
-		if !reflect.DeepEqual(expected, got) {
-			t.Errorf(errFmt, expected, got)
-		}
-	})
 }

--- a/pkg/router/route_test.go
+++ b/pkg/router/route_test.go
@@ -27,32 +27,6 @@ func TestRouteUnmarshalingShould(t *testing.T) {
 	})
 }
 
-func TestRouteInitShould(t *testing.T) {
-	t.Run("generate the expected stride value for each route.", func(t *testing.T) {
-		tRoute := Route{
-			Handlers: []Handler{
-				{Weight: 1},
-				{Weight: 2},
-			},
-		}
-
-		tRoute.Init()
-
-		expected := []uint{2, 1}
-		got := make([]uint, 0, len(tRoute.strideHandlers))
-		for _, sH := range tRoute.strideHandlers {
-			got = append(got, sH.stride)
-		}
-
-		for i, expectedStride := range expected {
-			if expectedStride != got[i] {
-				t.Errorf(errFmt, expectedStride, got[i])
-			}
-		}
-
-	})
-}
-
 func TestHandlerSelectionShould(t *testing.T) {
 
 }

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -9,6 +9,10 @@ import (
 
 type ErrRouteMatchFailure struct{}
 
+var (
+	TestHandler Handler = Handler{Weight: 1, ResponseStatus: 200, StaticResponse: "Ok"}
+)
+
 func routerHelper(req *http.Request, route *Route) bool {
 	rm := &mux.RouteMatch{}
 	router, _ := New([]*Route{route})
@@ -24,8 +28,9 @@ func TestRouterShouldMatch(t *testing.T) {
 		}
 
 		route := &Route{
-			Path:   "/test",
-			Method: "GET",
+			Path:     "/test",
+			Method:   "GET",
+			Handlers: []Handler{TestHandler},
 		}
 
 		if !routerHelper(req, route) {
@@ -40,8 +45,9 @@ func TestRouterShouldMatch(t *testing.T) {
 		}
 
 		route := &Route{
-			Path:   "/test/{key}",
-			Method: "GET",
+			Path:     "/test/{key}",
+			Method:   "GET",
+			Handlers: []Handler{TestHandler},
 		}
 
 		if !routerHelper(req, route) {
@@ -63,6 +69,7 @@ func TestRouterShouldMatch(t *testing.T) {
 			RequestHeaders: map[string]string{
 				"TestHeader": "present",
 			},
+			Handlers: []Handler{TestHandler},
 		}
 
 		if !routerHelper(req, route) {
@@ -82,6 +89,7 @@ func TestRouterShouldMatch(t *testing.T) {
 			QueryParams: map[string]string{
 				"testparam": "present",
 			},
+			Handlers: []Handler{TestHandler},
 		}
 
 		if !routerHelper(req, route) {
@@ -98,8 +106,9 @@ func TestRouterShouldNotMatch(t *testing.T) {
 		}
 
 		route := &Route{
-			Path:   "/test",
-			Method: "POST",
+			Path:     "/test",
+			Method:   "POST",
+			Handlers: []Handler{TestHandler},
 		}
 
 		if routerHelper(req, route) {
@@ -119,6 +128,7 @@ func TestRouterShouldNotMatch(t *testing.T) {
 			RequestHeaders: map[string]string{
 				"TestHeader": "present",
 			},
+			Handlers: []Handler{TestHandler},
 		}
 
 		if routerHelper(req, route) {
@@ -138,6 +148,7 @@ func TestRouterShouldNotMatch(t *testing.T) {
 			QueryParams: map[string]string{
 				"testparam": "present",
 			},
+			Handlers: []Handler{TestHandler},
 		}
 
 		if routerHelper(req, route) {

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -9,14 +9,6 @@ import (
 
 type ErrRouteMatchFailure struct{}
 
-func generateTestHandler() []Handler {
-	return []Handler{Handler{
-		Weight:         1,
-		StaticResponse: "Ok",
-		ResponseStatus: 200,
-	}}
-}
-
 func routerHelper(req *http.Request, route *Route) bool {
 	rm := &mux.RouteMatch{}
 	router, _ := New([]*Route{route})


### PR DESCRIPTION
# Introduction
This change switches the handler selection process on a given route away from a lottery system that can generate non-deterministic route selections to a deterministic stride selection process.

# Linked Issues
resolves #58 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment

